### PR TITLE
feat: add account settings and admin panel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,9 @@ import { AuthProvider } from "./contexts/AuthContext";
 import ProtectedRoute from "./components/ProtectedRoute";
 import LoginPage from "./components/LoginPage";
 import Dashboard from "./components/Dashboard";
+import AccountSettings from "./components/AccountSettings";
+import AdminDashboard from "./components/AdminDashboard";
+import AdminRoute from "./components/AdminRoute";
 import "./styles/modern.css";
 
 const theme = createTheme({
@@ -94,6 +97,22 @@ function App() {
                   <ProtectedRoute>
                     <Dashboard />
                   </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/account"
+                element={
+                  <ProtectedRoute>
+                    <AccountSettings />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/admin"
+                element={
+                  <AdminRoute>
+                    <AdminDashboard />
+                  </AdminRoute>
                 }
               />
               <Route path="/" element={<Navigate to="/dashboard" replace />} />

--- a/src/components/AccountSettings.js
+++ b/src/components/AccountSettings.js
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { useAuth } from "../contexts/AuthContext";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { Button } from "./ui/button";
+import { Card, CardHeader, CardTitle, CardContent } from "./ui/card";
+
+const AccountSettings = () => {
+  const { user, updateProfile } = useAuth();
+  const [formData, setFormData] = useState({
+    name: user?.name || "",
+    email: user?.email || "",
+  });
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setMessage("");
+    const result = await updateProfile(formData);
+    if (result.success) {
+      setMessage("Profile updated successfully");
+    } else {
+      setMessage(result.error);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Account Settings</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                name="email"
+                type="email"
+                value={formData.email}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            {message && <p className="text-sm text-green-500">{message}</p>}
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Saving..." : "Save"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default AccountSettings;

--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import { usersAPI } from "../services/api";
+import { Card, CardHeader, CardTitle, CardContent } from "./ui/card";
+
+const AdminDashboard = () => {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadUsers = async () => {
+      try {
+        const data = await usersAPI.getAllUsers();
+        setUsers(data);
+      } catch (error) {
+        console.error("Failed to load users:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadUsers();
+  }, []);
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="min-h-screen p-4 bg-gray-50">
+      <Card className="max-w-3xl mx-auto">
+        <CardHeader>
+          <CardTitle>User Management</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {users.map((u) => (
+              <div
+                key={u.id}
+                className="flex items-center justify-between border rounded p-2"
+              >
+                <div>
+                  <p className="font-medium">{u.name}</p>
+                  <p className="text-sm text-gray-500">{u.email}</p>
+                </div>
+                <div className="text-sm capitalize">{u.role}</div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/src/components/AdminRoute.js
+++ b/src/components/AdminRoute.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+import { Box, CircularProgress } from "@mui/material";
+
+const AdminRoute = ({ children }) => {
+  const { user, isAuthenticated, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "100vh",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!isAuthenticated || user?.role !== "admin") {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return children;
+};
+
+export default AdminRoute;

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -328,6 +328,26 @@ const Dashboard = () => {
               <AccountCircle sx={{ mr: 1 }} />
               {user?.name}
             </MenuItem>
+            <MenuItem
+              onClick={() => {
+                handleMenuClose();
+                navigate("/account");
+              }}
+            >
+              <AccountCircle sx={{ mr: 1 }} />
+              Account Settings
+            </MenuItem>
+            {user?.role === "admin" && (
+              <MenuItem
+                onClick={() => {
+                  handleMenuClose();
+                  navigate("/admin");
+                }}
+              >
+                <DashboardIcon sx={{ mr: 1 }} />
+                Admin Panel
+              </MenuItem>
+            )}
             <MenuItem onClick={handleLogout}>
               <ExitToApp sx={{ mr: 1 }} />
               Logout

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -99,6 +99,25 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
+  const updateProfile = async (data) => {
+    try {
+      setLoading(true);
+      const response = await authAPI.updateProfile(data);
+      const { user: updatedUser } = response;
+      Cookies.set("user_data", JSON.stringify(updatedUser), { expires: 1 });
+      setUser(updatedUser);
+      return { success: true, user: updatedUser };
+    } catch (error) {
+      console.error("Update profile failed:", error);
+      return {
+        success: false,
+        error: error.response?.data?.message || "Update failed",
+      };
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const logout = () => {
     Cookies.remove("auth_token");
     Cookies.remove("user_data");
@@ -112,6 +131,7 @@ export const AuthProvider = ({ children }) => {
     loading,
     login,
     register,
+    updateProfile,
     logout,
   };
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -53,6 +53,11 @@ export const authAPI = {
     const response = await api.get("/auth/profile");
     return response.data;
   },
+
+  updateProfile: async (data) => {
+    const response = await api.patch("/auth/profile", data);
+    return response.data;
+  },
 };
 
 // Files API
@@ -164,6 +169,17 @@ export const foldersAPI = {
 
   deleteFolder: async (folderId) => {
     const response = await api.delete(`/folders/${folderId}`);
+    return response.data;
+  },
+};
+
+export const usersAPI = {
+  getAllUsers: async () => {
+    const response = await api.get("/users");
+    return response.data;
+  },
+  updateUser: async (userId, data) => {
+    const response = await api.patch(`/users/${userId}`, data);
     return response.data;
   },
 };


### PR DESCRIPTION
## Summary
- add user account settings page styled with shadcn components
- provide admin dashboard route for managing users
- extend auth context and API for profile and user management

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36537ed648324b3183de3a72d2e3e