### PR TITLE
Configure PostCSS to enable Tailwind CSS

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- add PostCSS configuration to load Tailwind CSS and autoprefixer

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a368657bf483248ab98cf75fd25715