### PR TITLE
feat: add service for admin user list

### DIFF
--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { usersAPI } from "../services/api";
+import { usersAPI } from "../services/users";
 import {
   Alert,
   Box,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -173,15 +173,4 @@ export const foldersAPI = {
   },
 };
 
-export const usersAPI = {
-  getAllUsers: async () => {
-    const response = await api.get("/users");
-    return response.data;
-  },
-  updateUser: async (userId, data) => {
-    const response = await api.patch(`/users/${userId}`, data);
-    return response.data;
-  },
-};
-
 export default api;

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -1,0 +1,14 @@
+import api from "./api";
+
+export const usersAPI = {
+  getAllUsers: async () => {
+    const response = await api.get("/users");
+    return response.data;
+  },
+  updateUser: async (userId, data) => {
+    const response = await api.patch(`/users/${userId}`, data);
+    return response.data;
+  },
+};
+
+export default usersAPI;


### PR DESCRIPTION
## Summary
- add users service to fetch and update users for admin dashboard
- wire admin dashboard to new users service

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a40ba64b908324b20bfe4afd0e154d