### PR TITLE
feat: support multiple user roles

### DIFF
--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -15,6 +15,8 @@ import {
   TableHead,
   TableRow,
   Typography,
+  Checkbox,
+  ListItemText,
 } from "@mui/material";
 
 const AdminDashboard = () => {
@@ -36,16 +38,16 @@ const AdminDashboard = () => {
     loadUsers();
   }, []);
 
-  const handleRoleChange = (id, role) => {
+  const handleRolesChange = (id, roles) => {
     setUsers((prev) =>
-      prev.map((u) => (u.id === id ? { ...u, role } : u))
+      prev.map((u) => (u.id === id ? { ...u, roles } : u))
     );
   };
 
   const handleUpdate = async (id) => {
     const user = users.find((u) => u.id === id);
     try {
-      await usersAPI.updateUser(id, { role: user.role });
+      await usersAPI.updateUser(id, { roles: user.roles });
       setMessage("User updated successfully");
     } catch (error) {
       console.error("Failed to update user:", error);
@@ -77,7 +79,7 @@ const AdminDashboard = () => {
               <TableRow>
                 <TableCell>Name</TableCell>
                 <TableCell>Email</TableCell>
-                <TableCell>Role</TableCell>
+                <TableCell>Roles</TableCell>
                 <TableCell align="right">Actions</TableCell>
               </TableRow>
             </TableHead>
@@ -90,12 +92,18 @@ const AdminDashboard = () => {
                   <TableCell>{u.email}</TableCell>
                   <TableCell>
                     <Select
-                      value={u.role}
-                      onChange={(e) => handleRoleChange(u.id, e.target.value)}
+                      multiple
+                      value={u.roles || []}
+                      onChange={(e) => handleRolesChange(u.id, e.target.value)}
                       size="small"
+                      renderValue={(selected) => selected.join(", ")}
                     >
-                      <MenuItem value="user">user</MenuItem>
-                      <MenuItem value="admin">admin</MenuItem>
+                      {['user', 'admin'].map((role) => (
+                        <MenuItem key={role} value={role}>
+                          <Checkbox checked={u.roles?.includes(role)} />
+                          <ListItemText primary={role} />
+                        </MenuItem>
+                      ))}
                     </Select>
                   </TableCell>
                   <TableCell align="right">

--- a/src/components/AdminRoute.js
+++ b/src/components/AdminRoute.js
@@ -21,7 +21,7 @@ const AdminRoute = ({ children }) => {
     );
   }
 
-  if (!isAuthenticated || user?.role !== "admin") {
+  if (!isAuthenticated || !user?.roles?.includes("admin")) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -337,7 +337,7 @@ const Dashboard = () => {
               <AccountCircle sx={{ mr: 1 }} />
               Account Settings
             </MenuItem>
-            {user?.role === "admin" && (
+            {user?.roles?.includes("admin") && (
               <MenuItem
                 onClick={() => {
                   handleMenuClose();


### PR DESCRIPTION
## Summary
- allow assigning multiple roles per user in admin dashboard
- check for admin role using roles list across the app

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4abbe20708324ac8700da26211442