### PR TITLE
feat: optimize interface components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import {
   BrowserRouter as Router,
   Routes,
@@ -6,14 +6,15 @@ import {
   Navigate,
 } from "react-router-dom";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import { CssBaseline, Box } from "@mui/material";
+import { CssBaseline, Box, CircularProgress } from "@mui/material";
 import { AuthProvider } from "./contexts/AuthContext";
 import ProtectedRoute from "./components/ProtectedRoute";
-import LoginPage from "./components/LoginPage";
-import Dashboard from "./components/Dashboard";
-import AccountSettings from "./components/AccountSettings";
-import AdminDashboard from "./components/AdminDashboard";
 import AdminRoute from "./components/AdminRoute";
+
+const LoginPage = lazy(() => import("./components/LoginPage"));
+const Dashboard = lazy(() => import("./components/Dashboard"));
+const AccountSettings = lazy(() => import("./components/AccountSettings"));
+const AdminDashboard = lazy(() => import("./components/AdminDashboard"));
 
 const theme = createTheme({
   palette: {
@@ -88,34 +89,42 @@ function App() {
       <AuthProvider>
         <Router>
           <Box sx={{ minHeight: "100vh" }}>
-            <Routes>
-              <Route path="/login" element={<LoginPage />} />
-              <Route
-                path="/dashboard"
-                element={
-                  <ProtectedRoute>
-                    <Dashboard />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/account"
-                element={
-                  <ProtectedRoute>
-                    <AccountSettings />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin"
-                element={
-                  <AdminRoute>
-                    <AdminDashboard />
-                  </AdminRoute>
-                }
-              />
-              <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            </Routes>
+            <Suspense
+              fallback={
+                <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+                  <CircularProgress />
+                </Box>
+              }
+            >
+              <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route
+                  path="/dashboard"
+                  element={
+                    <ProtectedRoute>
+                      <Dashboard />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/account"
+                  element={
+                    <ProtectedRoute>
+                      <AccountSettings />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin"
+                  element={
+                    <AdminRoute>
+                      <AdminDashboard />
+                    </AdminRoute>
+                  }
+                />
+                <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              </Routes>
+            </Suspense>
           </Box>
         </Router>
       </AuthProvider>

--- a/src/components/FileGrid.js
+++ b/src/components/FileGrid.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, memo } from "react";
 import {
   Grid,
   Card,
@@ -29,7 +29,7 @@ import {
 } from "@mui/icons-material";
 import { filesAPI } from "../services/api";
 
-const FileGrid = ({ files, loading, onFileDelete }) => {
+const FileGridComponent = ({ files, loading, onFileDelete }) => {
   const [previewFile, setPreviewFile] = useState(null);
   const [previewOpen, setPreviewOpen] = useState(false);
   const theme = useTheme();
@@ -397,4 +397,4 @@ const FileGrid = ({ files, loading, onFileDelete }) => {
   );
 };
 
-export default FileGrid;
+export default memo(FileGridComponent);

--- a/src/components/FolderList.js
+++ b/src/components/FolderList.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, memo } from "react";
 import {
   List,
   ListItem,
@@ -32,7 +32,7 @@ import {
 } from "@mui/icons-material";
 import { foldersAPI } from "../services/api";
 
-const FolderList = ({
+const FolderListComponent = ({
   folders,
   onFolderClick,
   currentFolder,
@@ -325,4 +325,4 @@ const FolderList = ({
   );
 };
 
-export default FolderList;
+export default memo(FolderListComponent);


### PR DESCRIPTION
## Summary
- lazy load major pages and show loading spinner while modules load
- memoize heavy UI lists to avoid redundant renders

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4b1c2b70c8324b6fd4079cff68cf0