### PR TITLE
fix: correct API base URL

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import Cookies from "js-cookie";
 
-const API_BASE_URL = "https://images-storage-nestjs-production.up.railway.app/"; // Backend URL
+const API_BASE_URL = "https://images-storage-nestjs-production.up.railway.app"; // Backend URL without trailing slash
 
 // Create axios instance
 const api = axios.create({


### PR DESCRIPTION
## Summary
- fix API base URL to avoid double slash in requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a701a4b920832483c2b104cc8af0b7