### PR TITLE
feat: add authentication and file explorer UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,22 @@
 import React from 'react';
-import ImageUploader from './components/ImageUploader';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { AuthProvider } from './contexts/AuthContext';
+import Login from './components/Login';
+import Register from './components/Register';
+import Dashboard from './components/Dashboard';
+import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
   return (
-    <div>
-      <h1>Image Storage</h1>
-      <ImageUploader />
-    </div>
+    <AuthProvider>
+      <Router>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+        </Routes>
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,0 +1,38 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { Grid, Box, Typography } from '@mui/material';
+import Header from './Header';
+import FolderTree from './FolderTree';
+import FileList from './FileList';
+import { AuthContext } from '../contexts/AuthContext';
+import { fetchFolderFiles } from '../services/api';
+
+const Dashboard = () => {
+  const { user } = useContext(AuthContext);
+  const [currentFolder, setCurrentFolder] = useState(null);
+  const [files, setFiles] = useState([]);
+
+  useEffect(() => {
+    if (currentFolder) {
+      fetchFolderFiles(currentFolder.id).then(setFiles);
+    }
+  }, [currentFolder]);
+
+  return (
+    <Box>
+      <Header />
+      <Grid container>
+        <Grid item xs={3}>
+          <FolderTree userId={user?.id} onSelectFolder={setCurrentFolder} />
+        </Grid>
+        <Grid item xs={9}>
+          <Box p={2}>
+            <Typography variant="h6">{currentFolder ? currentFolder.name : 'Select a folder'}</Typography>
+            <FileList files={files} />
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default Dashboard;

--- a/src/components/FileList.js
+++ b/src/components/FileList.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { List, ListItem, ListItemText } from '@mui/material';
+
+const FileList = ({ files }) => (
+  <List>
+    {files.map((file) => (
+      <ListItem key={file.id}>
+        <ListItemText primary={file.name} />
+      </ListItem>
+    ))}
+  </List>
+);
+
+export default FileList;

--- a/src/components/FolderTree.js
+++ b/src/components/FolderTree.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { List, ListItemButton, ListItemText } from '@mui/material';
+import { fetchFolders } from '../services/api';
+
+const renderTree = (nodes, onSelect, level = 0) => (
+  nodes.map(node => (
+    <div key={node.id}>
+      <ListItemButton sx={{ pl: level * 2 }} onClick={() => onSelect(node)}>
+        <ListItemText primary={node.name} />
+      </ListItemButton>
+      {node.children && node.children.length > 0 && renderTree(node.children, onSelect, level + 1)}
+    </div>
+  ))
+);
+
+const FolderTree = ({ userId, onSelectFolder }) => {
+  const [folders, setFolders] = useState([]);
+
+  useEffect(() => {
+    if (userId) {
+      fetchFolders(userId).then(setFolders);
+    }
+  }, [userId]);
+
+  return (
+    <List>
+      {renderTree(folders, onSelectFolder)}
+    </List>
+  );
+};
+
+export default FolderTree;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,41 @@
+import React, { useContext, useState } from 'react';
+import { AppBar, Toolbar, Typography, IconButton, Menu, MenuItem } from '@mui/material';
+import AccountCircle from '@mui/icons-material/AccountCircle';
+import { AuthContext } from '../contexts/AuthContext';
+
+const Header = () => {
+  const { user, logout } = useContext(AuthContext);
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <AppBar position="static" color="default" sx={{ bgcolor: '#fff', color: '#000' }}>
+      <Toolbar>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Image Storage
+        </Typography>
+        {user && (
+          <>
+            <IconButton color="inherit" onClick={handleMenu}>
+              <AccountCircle />
+            </IconButton>
+            <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+              <MenuItem disabled>{user.name || user.email}</MenuItem>
+              <MenuItem onClick={handleClose}>Edit Profile</MenuItem>
+              <MenuItem onClick={() => { handleClose(); logout(); }}>Logout</MenuItem>
+            </Menu>
+          </>
+        )}
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default Header;

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,0 +1,39 @@
+import React, { useState, useContext } from 'react';
+import { Box, TextField, Button, Typography } from '@mui/material';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../contexts/AuthContext';
+
+const Login = () => {
+  const { login } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      navigate('/');
+    } catch (err) {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" alignItems="center" mt={8}>
+      <Typography variant="h5">Login</Typography>
+      <Box component="form" onSubmit={handleSubmit} sx={{ mt: 2, width: 300 }}>
+        <TextField fullWidth margin="normal" label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <TextField fullWidth margin="normal" type="password" label="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        {error && <Typography color="error">{error}</Typography>}
+        <Button fullWidth variant="contained" type="submit" sx={{ mt: 2, bgcolor: '#000', color: '#fff' }}>Login</Button>
+        <Typography variant="body2" sx={{ mt: 2 }}>
+          No account? <Link to="/register">Register</Link>
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default Login;

--- a/src/components/ProtectedRoute.js
+++ b/src/components/ProtectedRoute.js
@@ -1,0 +1,13 @@
+import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
+import { AuthContext } from '../contexts/AuthContext';
+
+const ProtectedRoute = ({ children }) => {
+  const { user } = useContext(AuthContext);
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
+
+export default ProtectedRoute;

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -1,0 +1,41 @@
+import React, { useState, useContext } from 'react';
+import { Box, TextField, Button, Typography } from '@mui/material';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../contexts/AuthContext';
+
+const Register = () => {
+  const { register } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await register({ name, email, password });
+      navigate('/');
+    } catch (err) {
+      setError('Registration failed');
+    }
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" alignItems="center" mt={8}>
+      <Typography variant="h5">Register</Typography>
+      <Box component="form" onSubmit={handleSubmit} sx={{ mt: 2, width: 300 }}>
+        <TextField fullWidth margin="normal" label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <TextField fullWidth margin="normal" label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <TextField fullWidth margin="normal" type="password" label="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        {error && <Typography color="error">{error}</Typography>}
+        <Button fullWidth variant="contained" type="submit" sx={{ mt: 2, bgcolor: '#000', color: '#fff' }}>Register</Button>
+        <Typography variant="body2" sx={{ mt: 2 }}>
+          Have an account? <Link to="/login">Login</Link>
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default Register;

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,0 +1,42 @@
+import React, { createContext, useState, useEffect } from 'react';
+import Cookies from 'js-cookie';
+import { login as apiLogin, register as apiRegister, getProfile } from '../services/api';
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const data = await getProfile();
+        setUser(data);
+      } catch (err) {
+        setUser(null);
+      }
+    };
+    fetchUser();
+  }, []);
+
+  const login = async (email, password) => {
+    const data = await apiLogin(email, password);
+    setUser(data.user);
+  };
+
+  const register = async (info) => {
+    const data = await apiRegister(info);
+    setUser(data.user);
+  };
+
+  const logout = () => {
+    Cookies.remove('jwt');
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,10 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
-  padding: 20px;
+  background-color: #fff;
+  color: #000;
+}
+
+a {
+  color: #000;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,21 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#000' },
+    background: { default: '#fff' },
+    text: { primary: '#000' },
+  },
+});
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <ThemeProvider theme={theme}>
+    <CssBaseline />
+    <App />
+  </ThemeProvider>
+);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,12 +1,48 @@
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3000';
+
+const request = async (url, options = {}) => {
+  const res = await fetch(`${API_URL}${url}`, {
+    credentials: 'include',
+    ...options,
+  });
+  if (!res.ok) {
+    throw new Error('API error');
+  }
+  return res.json();
+};
+
+export const login = (email, password) =>
+  request('/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+
+export const register = (data) =>
+  request('/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+
+export const getProfile = () => request('/auth/profile');
+
+export const updateProfile = (data) =>
+  request('/auth/profile', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+
+export const fetchFolders = (userId) => request(`/folders/user/${userId}`);
+
+export const fetchFolderFiles = (folderId) => request(`/folders/${folderId}/files`);
+
 export const uploadImage = async (file) => {
   const formData = new FormData();
   formData.append('image', file);
-  const response = await fetch('/upload', {
+  return request('/files/upload', {
     method: 'POST',
     body: formData,
   });
-  if (!response.ok) {
-    throw new Error('Upload failed');
-  }
-  return response.json();
 };


### PR DESCRIPTION
## Summary
- add login and registration pages with context-based authentication
- show user menu with profile actions and logout
- display folder tree and current folder files in dashboard with monochrome theme

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7eebde5a8832485d7e03d7d976e5d