### PR TITLE
feat: add file deletion service and UI

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -17,6 +17,10 @@ const Dashboard = () => {
     }
   }, [currentFolder]);
 
+  const handleFileDeleted = (id) => {
+    setFiles((prev) => prev.filter((file) => file.id !== id));
+  };
+
   return (
     <Box>
       <Header />
@@ -27,7 +31,7 @@ const Dashboard = () => {
         <Grid item xs={9}>
           <Box p={2}>
             <Typography variant="h6">{currentFolder ? currentFolder.name : 'Select a folder'}</Typography>
-            <FileList files={files} />
+            <FileList files={files} onDelete={handleFileDeleted} />
           </Box>
         </Grid>
       </Grid>

--- a/src/components/FileList.js
+++ b/src/components/FileList.js
@@ -1,14 +1,32 @@
 import React from 'react';
-import { List, ListItem, ListItemText } from '@mui/material';
+import { List, ListItem, ListItemText, IconButton } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { deleteFile } from '../services/api';
 
-const FileList = ({ files }) => (
-  <List>
-    {files.map((file) => (
-      <ListItem key={file.id}>
-        <ListItemText primary={file.name} />
-      </ListItem>
-    ))}
-  </List>
-);
+const FileList = ({ files, onDelete }) => {
+  const handleDelete = async (id) => {
+    await deleteFile(id);
+    if (onDelete) {
+      onDelete(id);
+    }
+  };
+
+  return (
+    <List>
+      {files.map((file) => (
+        <ListItem
+          key={file.id}
+          secondaryAction={
+            <IconButton edge="end" aria-label="delete" onClick={() => handleDelete(file.id)}>
+              <DeleteIcon />
+            </IconButton>
+          }
+        >
+          <ListItemText primary={file.name} />
+        </ListItem>
+      ))}
+    </List>
+  );
+};
 
 export default FileList;

--- a/src/components/FileList.test.js
+++ b/src/components/FileList.test.js
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FileList from './FileList';
+import { deleteFile } from '../services/api';
+
+jest.mock('../services/api', () => ({
+  deleteFile: jest.fn(() => Promise.resolve()),
+}));
+
+test('calls delete service and onDelete when delete button is clicked', async () => {
+  const files = [{ id: 1, name: 'test.png' }];
+  const handleDelete = jest.fn();
+  render(<FileList files={files} onDelete={handleDelete} />);
+
+  const button = screen.getByLabelText(/delete/i);
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(deleteFile).toHaveBeenCalledWith(1);
+    expect(handleDelete).toHaveBeenCalledWith(1);
+  });
+});
+

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -38,6 +38,19 @@ export const fetchFolders = (userId) => request(`/folders/user/${userId}`);
 
 export const fetchFolderFiles = (folderId) => request(`/folders/${folderId}/files`);
 
+export const createFolder = (name, parentId) =>
+  request('/folders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, parentId }),
+  });
+
+export const deleteFolder = (folderId) =>
+  request(`/folders/${folderId}`, { method: 'DELETE' });
+
+export const deleteFile = (fileId) =>
+  request(`/files/${fileId}`, { method: 'DELETE' });
+
 export const uploadImage = async (file) => {
   const formData = new FormData();
   formData.append('image', file);


### PR DESCRIPTION
## Summary
- expand API helper with folder and file management functions
- add delete button to file list and update dashboard on removal
- test file deletion interaction

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7fa95cee883248c259570d99a43ec