### PR TITLE
fix: switch API base URL to production server

### DIFF
--- a/FRONTEND_README.md
+++ b/FRONTEND_README.md
@@ -73,7 +73,7 @@ src/
 
 ## API Integration
 
-Backend URL: `http://localhost:3000`
+Backend URL: `https://images-storage-nestjs-production.up.railway.app`
 
 ### Endpoints được sử dụng:
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,6 @@
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3000';
+const API_URL =
+  process.env.REACT_APP_API_URL ||
+  'https://images-storage-nestjs-production.up.railway.app';
 
 const request = async (url, options = {}) => {
   const res = await fetch(`${API_URL}${url}`, {


### PR DESCRIPTION
## Summary
- use production API URL by default
- document production backend endpoint

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a814069c7c8324bae503636cc36a6e