### PR TITLE
Include JWT cookie in API requests

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,13 +1,25 @@
+import Cookies from 'js-cookie';
+
 const API_URL =
   process.env.REACT_APP_API_URL ||
   'https://images-storage-nestjs-production.up.railway.app';
 
 const request = async (url, options = {}) => {
+  const token = Cookies.get('jwt');
+  const headers = {
+    ...(options.headers || {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+
   const res = await fetch(`${API_URL}${url}`, {
     credentials: 'include',
     ...options,
+    headers,
   });
   if (!res.ok) {
+    if (res.status === 401) {
+      throw new Error('Unauthorized');
+    }
     throw new Error('API error');
   }
   return res.json();


### PR DESCRIPTION
## Summary
- send `Authorization` header using JWT cookie for every API request
- surface unauthorized responses as `Unauthorized` errors

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a8169296748324b73235562ae7edb4