### PR TITLE
Persist JWT after login

### DIFF
--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -21,11 +21,13 @@ export const AuthProvider = ({ children }) => {
 
   const login = async (email, password) => {
     const data = await apiLogin(email, password);
+    Cookies.set('jwt', data.access_token);
     setUser(data.user);
   };
 
   const register = async (info) => {
     const data = await apiRegister(info);
+    Cookies.set('jwt', data.access_token);
     setUser(data.user);
   };
 


### PR DESCRIPTION
## Summary
- store JWT from auth responses in cookies for later API calls

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a8185d387083248f9f6f2c1b680796