### PR TITLE
Preserve auth on reload and show root items

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -4,7 +4,7 @@ import Header from './Header';
 import FolderTree from './FolderTree';
 import FileList from './FileList';
 import { AuthContext } from '../contexts/AuthContext';
-import { fetchFolderFiles } from '../services/api';
+import { fetchFolderFiles, fetchUserFiles } from '../services/api';
 
 const Dashboard = () => {
   const { user } = useContext(AuthContext);
@@ -14,8 +14,12 @@ const Dashboard = () => {
   useEffect(() => {
     if (currentFolder) {
       fetchFolderFiles(currentFolder.id).then(setFiles);
+    } else if (user) {
+      fetchUserFiles(user.id).then((data) =>
+        setFiles(data.filter((file) => !file.folderId))
+      );
     }
-  }, [currentFolder]);
+  }, [currentFolder, user]);
 
   const handleFileDeleted = (id) => {
     setFiles((prev) => prev.filter((file) => file.id !== id));
@@ -30,7 +34,7 @@ const Dashboard = () => {
         </Grid>
         <Grid item xs={9}>
           <Box p={2}>
-            <Typography variant="h6">{currentFolder ? currentFolder.name : 'Select a folder'}</Typography>
+            <Typography variant="h6">{currentFolder ? currentFolder.name : 'Root'}</Typography>
             <FileList files={files} onDelete={handleFileDeleted} />
           </Box>
         </Grid>

--- a/src/components/FolderTree.js
+++ b/src/components/FolderTree.js
@@ -2,29 +2,24 @@ import React, { useEffect, useState } from 'react';
 import { List, ListItemButton, ListItemText } from '@mui/material';
 import { fetchFolders } from '../services/api';
 
-const renderTree = (nodes, onSelect, level = 0) => (
-  nodes.map(node => (
-    <div key={node.id}>
-      <ListItemButton sx={{ pl: level * 2 }} onClick={() => onSelect(node)}>
-        <ListItemText primary={node.name} />
-      </ListItemButton>
-      {node.children && node.children.length > 0 && renderTree(node.children, onSelect, level + 1)}
-    </div>
-  ))
-);
-
 const FolderTree = ({ userId, onSelectFolder }) => {
   const [folders, setFolders] = useState([]);
 
   useEffect(() => {
     if (userId) {
-      fetchFolders(userId).then(setFolders);
+      fetchFolders(userId).then((data) =>
+        setFolders(data.filter((folder) => !folder.parentId))
+      );
     }
   }, [userId]);
 
   return (
     <List>
-      {renderTree(folders, onSelectFolder)}
+      {folders.map((folder) => (
+        <ListItemButton key={folder.id} onClick={() => onSelectFolder(folder)}>
+          <ListItemText primary={folder.name} />
+        </ListItemButton>
+      ))}
     </List>
   );
 };

--- a/src/components/ProtectedRoute.js
+++ b/src/components/ProtectedRoute.js
@@ -3,7 +3,10 @@ import { Navigate } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
 
 const ProtectedRoute = ({ children }) => {
-  const { user } = useContext(AuthContext);
+  const { user, loading } = useContext(AuthContext);
+  if (loading) {
+    return null;
+  }
   if (!user) {
     return <Navigate to="/login" replace />;
   }

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -6,6 +6,7 @@ export const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -14,6 +15,8 @@ export const AuthProvider = ({ children }) => {
         setUser(data);
       } catch (err) {
         setUser(null);
+      } finally {
+        setLoading(false);
       }
     };
     fetchUser();
@@ -37,7 +40,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout }}>
+    <AuthContext.Provider value={{ user, login, register, logout, loading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -52,6 +52,8 @@ export const fetchFolders = (userId) => request(`/folders/user/${userId}`);
 
 export const fetchFolderFiles = (folderId) => request(`/folders/${folderId}/files`);
 
+export const fetchUserFiles = (userId) => request(`/files/user/${userId}`);
+
 export const createFolder = (name, parentId) =>
   request('/folders', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- keep authenticated user after refresh by adding loading state in auth context and updating protected routes
- display only root-level folders and files, fetching user files when no folder is selected
- expose `fetchUserFiles` API helper for retrieving user files

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a82c6b363483248585f6214ca1898c